### PR TITLE
Add Jekyll Config, Default and Post Layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_site/
+.DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,29 @@
+# Site level variables
+title: "Llogiq on stuff"
+subtitle: "Stuff is...complicated"
+author:
+  name: "Llogiq"
+  github: "https://github.com/llogiq"
+
+# Jekyll config
+future: false
+timezone: "UTC"
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+
+# Set defaults for pages and posts
+defaults:
+  -
+    scope:
+      path: ""
+      type: "posts"
+    values:
+      layout: "post"
+  -
+    scope:
+      path: ""
+      type: "pages"
+    values:
+      layout: "default"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <title>{% if page.title %}{{ page.title }} &mdash; {% endif %}{{ site.title }}</title>
+
+    <link rel="stylesheet" href="/stylesheets/styles.css">
+    <link rel="stylesheet" href="/stylesheets/pygment_trac.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <!--[if lt IE 9]>
+    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="wrapper">
+      <header>
+        <h1>
+          {{site.title}}
+        </h1>
+        <p>
+          {{site.subtitle}}
+        </p>
+        <p class="view"><a href="/">Home</a></p>
+        <p class="view"><a href="{{site.author.github}}">View My GitHub Profile</a></p>
+
+      </header>
+      <section>
+        {{content}}
+      </section>
+      <footer>
+        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
+      </footer>
+    </div>
+    <script src="/javascripts/scale.fix.js"></script>
+    
+  </body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,15 @@
+---
+layout: default
+---
+<article>
+  <h1>
+    {{page.title}}
+  </h1>
+  <p>
+    <time datetime="{{page.date}}">
+      {{page.date | date_to_long_string }}
+    </time>
+  </p>
+
+  {{content}}
+</article>

--- a/index.html
+++ b/index.html
@@ -1,40 +1,23 @@
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <title>Llogiq on stuff by llogiq</title>
-
-    <link rel="stylesheet" href="stylesheets/styles.css">
-    <link rel="stylesheet" href="stylesheets/pygment_trac.css">
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-    <!--[if lt IE 9]>
-    <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-  </head>
-  <body>
-    <div class="wrapper">
-      <header>
-        <h1>Llogiq on stuff</h1>
-        <p>Stuff is...complicated</p>
-
-
-        <p class="view"><a href="https://github.com/llogiq">View My GitHub Profile</a></p>
-
-      </header>
-      <section>
-        <h3>
-<a id="what-is-this-about" class="anchor" href="#what-is-this-about" aria-hidden="true"><span class="octicon octicon-link"></span></a>What is this about?</h3>
+---
+title: "Start"
+---
+<h2>
+  <a id="what-is-this-about" class="anchor" href="#what-is-this-about" aria-hidden="true"><span class="octicon octicon-link"></span></a>
+  What is this about?
+</h2>
 
 <p>I plan to write here about interesting things that I encounter, stuff I've coded, and whatever I feel like writing about.</p>
 
 <p>Since I'm currently learning <a href="https://http://www.rust-lang.org/">Rust</a>, expect some content regarding this cool language. I also work in Java, so that may show up here and there, too.</p>
-      </section>
-      <footer>
-        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
-      </footer>
-    </div>
-    <script src="javascripts/scale.fix.js"></script>
-    
-  </body>
-</html>
+
+<h2>
+  Posts
+</h2>
+
+<ul>
+  {% for post in site.posts %}
+    <li>
+      <a href="{{ post.url }}">{{ post.title }}</a> ({{post.date | date: "%Y-%m-%d"}})
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
You mentioned on reddit that you needed some help with Jekyll, so I took a look this repo and added some stuff. Basically, this is just some config and two layouts (for the start page and the posts).

Since the post template is the same as the start page template, it uses the same CSS and thus the same, tiny font size. Changing it is easy enough, though.

(This also reformats your 'Workflow' post since the title is part of the template now.)
