### PR TITLE
syntax highlighting for Rust "From Into" post

### DIFF
--- a/_posts/2015-11-27-from-into.md
+++ b/_posts/2015-11-27-from-into.md
@@ -38,7 +38,7 @@ implement `From<&Blob> for &Bar` and while we're at it implement
 [code](https://play.rust-lang.org/?gist=13e3caea0066b4864ec9&version=stable)
 is:
 
-```
+```rust
 use std::convert::*;
 
 struct Bar { num: i32 }
@@ -71,7 +71,7 @@ Can we move the `.into()` into our `foo` function? Perhaps by using the `Into`
 trait? Let's try that. We change `foo(_)` to the 
 [following](https://play.rust-lang.org/?gist=26282e6764552ce8e55f&version=stable):
 
-```
+```rust
 // foo is now generic: It takes anything that we can turn into a Bar reference 
 // of any lifetime (which btw. precludes us from returning the Bar reference)
 fn foo<'b, B: Into<&'b Bar>>(bar: B) {
@@ -105,7 +105,7 @@ implementation to create a new `Bar` without the reference. We also need to
 change `foo(_)` to take any `<B: Into<Bar>>` (removing the &'b) to 
 [get](https://play.rust-lang.org/?gist=cea08895a3e1ce1e98db&version=stable):
 
-```
+```rust
 impl<'a> From<&'a Blob> for Bar {
     fn from(blob: &'a Blob) -> Bar { blob.bar }
 }
@@ -126,7 +126,7 @@ Another option is to go on a pasture and find a `std::borrow::Cow`
 a lot of flexibility. We don't need that here, but for more complex `Bar`s, it 
 could be worth the price:
 
-```
+```rust
 use std::convert::*;
 use std::borrow::*;
 
@@ -189,7 +189,7 @@ example follows):
 a common wrapping Error looks something like this (if you’re lazy and don’t 
 impl `std::error::Error`):
 
-```
+```rust
 #[derive(Debug)]
 pub enum Error { TooLong(usize), Io(io::Error) }
 
@@ -200,7 +200,7 @@ impl From<io::Error> for Error {
 
 then you’re able to simply use `try!(_)` to wrap another error into yours.
 
-```
+```rust
 fn foobar() -> Result<String, Error> {
     let foo = try!(some_io_operation());
     match foo.len() {


### PR DESCRIPTION
The post about `From`/`Into` now has syntax highlighting.

You can enable highlighting for arbitrary code by using this:

<pre lang="markdown"><code>
```language
code
```
</code></pre>


For example:

<pre lang="markdown"><code>
```rust
fn main() {
    println!("Meow.");
}
```
</code></pre>
