### PR TITLE
Clarify 'cache: cargo' semantics

### DIFF
--- a/_posts/2016-07-05-travis.md
+++ b/_posts/2016-07-05-travis.md
@@ -42,10 +42,13 @@ don't have numbers, I remember noticing the speedup when making the switch for
 
 ### 2. Cache cargo dependencies
 
-With the line `cache: cargo` in your `.travis.yml`, travis will remember the 
-contents of your `$CARGO_HOME`, so that you only need to recompile dependencies 
+With the line `cache: cargo` in your `.travis.yml`, travis
+[will remember][cargo-cache] the contents of `$HOME/.cargo` and
+`$TRAVIS_BUILD_DIR/target`, so that you only need to recompile dependencies 
 if they or the compiler were upgraded. For some dependency-heavy projects, this 
 can make quite the difference.
+
+[cargo-cache]: https://docs.travis-ci.com/user/caching/#rust-cargo-cache
 
 ### 3. Only build what you need
 


### PR DESCRIPTION
Make it clearer why you won't need to recompile dependencies and link to caching documentation.
