### PR TITLE
Fix typo in 2024-03-28-easy.md

### DIFF
--- a/_posts/2024-03-28-easy.md
+++ b/_posts/2024-03-28-easy.md
@@ -51,7 +51,7 @@ So without further ado, here are the things we want to avoid learning, and how t
 
 ### Syntax
 
-Rust is not a small language. When starting out, for flow control it's best to stick to basic things like `if`, `for` and `while`. If you need to distinguish e.g. enum variants, you can also us `match`, but keep it simple: Only match one thing, and avoid more complex things like guard clauses:
+Rust is not a small language. When starting out, for flow control it's best to stick to basic things like `if`, `for` and `while`. If you need to distinguish e.g. enum variants, you can also use `match`, but keep it simple: Only match one thing, and avoid more complex things like guard clauses:
 
 ```rust
 // Don't nest patterns in match arms


### PR DESCRIPTION
`us` -> `use`